### PR TITLE
chore: add rules to ESLint

### DIFF
--- a/apps/api/.eslintrc.js
+++ b/apps/api/.eslintrc.js
@@ -1,28 +1,13 @@
 module.exports = {
   extends: ["custom"],
-  parser: '@typescript-eslint/parser',
   parserOptions: {
     project: 'tsconfig.json',
     tsconfigRootDir : __dirname, 
     sourceType: 'module',
   },
-  plugins: ['@typescript-eslint/eslint-plugin'],
-  extends: [
-    'plugin:@typescript-eslint/recommended',
-    'plugin:prettier/recommended',
-  ],
-  root: true,
   env: {
     node: true,
     jest: true,
   },
   ignorePatterns: ['.eslintrc.js'],
-  rules: {
-    '@typescript-eslint/interface-name-prefix': 'off',
-    '@typescript-eslint/explicit-function-return-type': ['warn'],
-    '@typescript-eslint/explicit-module-boundary-types': 'off',
-    '@typescript-eslint/no-explicit-any': ['warn'],
-    '@typescript-eslint/prefer-readonly': ['warn'],
-    '@typescript-eslint/no-unused-vars': ['warn', { 'ignoreRestSiblings': true }],
-  },
 };

--- a/apps/api/.eslintrc.js
+++ b/apps/api/.eslintrc.js
@@ -19,8 +19,9 @@ module.exports = {
   ignorePatterns: ['.eslintrc.js'],
   rules: {
     '@typescript-eslint/interface-name-prefix': 'off',
-    '@typescript-eslint/explicit-function-return-type': 'off',
+    '@typescript-eslint/explicit-function-return-type': ['warn'],
     '@typescript-eslint/explicit-module-boundary-types': 'off',
-    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-explicit-any': ['warn'],
+    '@typescript-eslint/prefer-readonly': ['warn'],
   },
 };

--- a/apps/api/.eslintrc.js
+++ b/apps/api/.eslintrc.js
@@ -23,5 +23,6 @@ module.exports = {
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': ['warn'],
     '@typescript-eslint/prefer-readonly': ['warn'],
+    '@typescript-eslint/no-unused-vars': ['warn', { 'ignoreRestSiblings': true }],
   },
 };

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -37,7 +37,6 @@
     "@types/node": "^16.0.0",
     "@types/supertest": "^2.0.11",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
-    "@typescript-eslint/parser": "^5.0.0",
     "eslint": "^8.0.1",
     "eslint-config-custom": "*",
     "eslint-config-prettier": "^8.3.0",

--- a/apps/web/.eslintrc.js
+++ b/apps/web/.eslintrc.js
@@ -1,6 +1,10 @@
 module.exports = {
-  root: true,
   extends: ["next", "custom"],
+  parserOptions: {
+    project: 'tsconfig.json',
+    tsconfigRootDir : __dirname,
+    sourceType: 'module',
+  },
   rules: {
     "@next/next/no-html-link-for-pages": "off",
     "react/jsx-key": "off",

--- a/packages/eslint-config-custom/index.js
+++ b/packages/eslint-config-custom/index.js
@@ -1,3 +1,17 @@
 module.exports = {
   extends: ["turbo", "prettier"],
+  parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint/eslint-plugin'],
+  extends: [
+    'plugin:@typescript-eslint/recommended',
+    'plugin:prettier/recommended',
+  ],
+  rules: {
+    '@typescript-eslint/interface-name-prefix': 'off',
+    '@typescript-eslint/explicit-function-return-type': ['warn'],
+    '@typescript-eslint/explicit-module-boundary-types': 'off',
+    '@typescript-eslint/no-explicit-any': ['warn'],
+    '@typescript-eslint/prefer-readonly': ['warn'],
+    '@typescript-eslint/no-unused-vars': ['warn', { 'ignoreRestSiblings': true }],
+  },
 };

--- a/packages/eslint-config-custom/package.json
+++ b/packages/eslint-config-custom/package.json
@@ -7,10 +7,11 @@
     "eslint": "^7.23.0",
     "eslint-config-next": "13.0.0",
     "eslint-config-prettier": "^8.3.0",
-    "eslint-plugin-react": "7.31.8",
-    "eslint-config-turbo": "latest"
+    "eslint-config-turbo": "latest",
+    "eslint-plugin-react": "7.31.8"
   },
   "devDependencies": {
+    "@typescript-eslint/parser": "^5.48.0",
     "typescript": "^4.7.4"
   },
   "publishConfig": {

--- a/packages/ui/.eslintrc.js
+++ b/packages/ui/.eslintrc.js
@@ -1,6 +1,10 @@
 module.exports = {
-  root: true,
   extends: ["next", "custom"],
+  parserOptions: {
+    project: 'tsconfig.json',
+    tsconfigRootDir : __dirname,
+    sourceType: 'module',
+  },
   rules: {
     "@next/next/no-html-link-for-pages": "off",
     "react/jsx-key": "off",

--- a/packages/ui/index.tsx
+++ b/packages/ui/index.tsx
@@ -1,1 +1,0 @@
-import * as React from "react";


### PR DESCRIPTION
- `@typescript-eslint/explicit-function-return-type`: kind of useless but it is better to explicitely type our functions return type.
- `typescript-eslint/no-explicit-any`: quite hard but it can become really messy if we just use `as any` everywhere.
- `@typescript-eslint/prefer-readonly`: mainly used inside services constructor (dependency injections)