### PR TITLE
build: build repo before running dev servers

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,9 +1,12 @@
 {
   "name": "types",
   "version": "0.0.0",
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "license": "MIT",
+  "scripts": {
+    "build": "tsc"
+  },
   "dependencies": {
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -47,5 +47,5 @@ export interface ConversationWithUnread {
   lastMessage: Date;
 }
 
-export * from '../src/enums';
-export * from '../src/entities';
+export * from './enums';
+export * from './entities';

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "tsconfig/nestjs.json",
+  "extends": "tsconfig/base.json",
   "compilerOptions": {
     "module": "commonjs",
     "removeComments": true,

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,3 +1,19 @@
 {
-  "extends": "tsconfig/base.json"
+  "extends": "tsconfig/nestjs.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "es2017",
+    "sourceMap": true,
+    "outDir": "./dist",
+    "baseUrl": "./",
+    "incremental": true,
+    "strictNullChecks": true,
+    "noImplicitAny": true,
+    "strictBindCallApply": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
 }

--- a/turbo.json
+++ b/turbo.json
@@ -9,6 +9,7 @@
       "outputs": []
     },
     "dev": {
+      "dependsOn": ["build"],
       "cache": false
     }
   }


### PR DESCRIPTION
Types packages is an ESModule however NestJS is built into CommonJS. That means that both package use different import systems and that caused conflicts.

Now, all packages are built before development servers are launched after all packages have been built.

The tsconfig.json files has been copied from the NestJS one, and everything was left as is. The file may be wrong in some points.