### PR TITLE
feat(api): associate refresh tokens to access tokens

### DIFF
--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -123,45 +123,65 @@ export class AuthService {
     return jwt.user;
   }
 
-  async createJwt(
+  async createJwtEntity(
     user: User,
     token_type: TokenTypeEnum = TokenTypeEnum.ACCESS_TOKEN,
-    expiresIn = '5m',
-  ): Promise<string> {
+    originToken: Jwt | null = null,
+  ): Promise<Jwt> {
     const jwtEntity = new Jwt();
     jwtEntity.user = user;
     jwtEntity.token_type = token_type;
+    jwtEntity.originToken = originToken;
     await this.jwtsRepository.save(jwtEntity).then((jwt) => {
       jwtEntity.id = jwt.id;
     });
-
-    const payload: JwtPayload = {
-      sub: user.id,
-      name: user.name,
-      jti: jwtEntity.id,
-    };
-    return this.jwtService.sign(payload, {
-      expiresIn: expiresIn,
-    });
+    return jwtEntity;
   }
 
   async revokeAllToken(user: User): Promise<void> {
     await this.jwtsRepository.delete({ user: { id: user.id } });
   }
 
-  async login(user: User, state?: State): Promise<AccessTokenResponse> {
-    const accessTokenPayload = this.createJwt(user);
-    const refreshTokenPayload = this.createJwt(
+  async createTokensPair(user: User): Promise<string[]> {
+    const accessTokenEntity = await this.createJwtEntity(user);
+    const refreshTokenEntity = await this.createJwtEntity(
       user,
       TokenTypeEnum.REFRESH_TOKEN,
-      '5d',
+      accessTokenEntity,
     );
+
+    return Promise.all([
+      this.jwtService.sign(
+        {
+          sub: user.id,
+          name: user.name,
+          jti: accessTokenEntity.id,
+        },
+        {
+          expiresIn: '5m',
+        },
+      ),
+      this.jwtService.sign(
+        {
+          sub: user.id,
+          name: user.name,
+          jti: refreshTokenEntity.id,
+        },
+        {
+          expiresIn: '5d',
+        },
+      ),
+    ]);
+  }
+
+  async login(user: User, state?: State): Promise<AccessTokenResponse> {
+    const [accessToken, refreshToken] = await this.createTokensPair(user);
     if (state) {
       this.statesRepository.delete({ token: state.token });
     }
     return {
-      access_token: await accessTokenPayload,
-      refresh_token: await refreshTokenPayload,
+      access_token: accessToken,
+      refresh_token: refreshToken,
     };
   }
 

--- a/packages/types/src/entities/jwt.entity.ts
+++ b/packages/types/src/entities/jwt.entity.ts
@@ -32,4 +32,7 @@ export class Jwt {
 
   @Column('boolean', { default: false })
   consumed!: boolean;
+
+  @ManyToOne(() => Jwt, (jwt) => jwt.id, { eager: true, nullable: true })
+  originToken!: Jwt | null;
 }

--- a/packages/types/src/entities/jwt.entity.ts
+++ b/packages/types/src/entities/jwt.entity.ts
@@ -33,6 +33,6 @@ export class Jwt {
   @Column('boolean', { default: false })
   consumed!: boolean;
 
-  @ManyToOne(() => Jwt, (jwt) => jwt.id, { eager: true, nullable: true })
+  @ManyToOne(() => Jwt, (jwt) => jwt.id, { eager: false, nullable: true })
   originToken!: Jwt | null;
 }


### PR DESCRIPTION
The association is useful to remove all refresh tokens associated to an access token (e.g. when logging out).