### PR TITLE
Reroute profile on oauth2 signup

### DIFF
--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -82,7 +82,10 @@ export class AuthController {
       return { message: 'Authentication factor needed', route: 'tfa' };
     }
     this.logger.log(`${user.name} logged in using OAuth2`);
-    return this.authService.login(user, state);
+    return this.authService.login(user, state).then((response) => ({
+      ...response,
+      username: user.newlyCreated ? user.name : undefined,
+    }));
   }
 
   @Post('register')

--- a/apps/api/src/auth/ft-oauth2.strategy.ts
+++ b/apps/api/src/auth/ft-oauth2.strategy.ts
@@ -36,6 +36,7 @@ export class FtOauth2Strategy extends PassportStrategy(Strategy) {
         name: ftUser.login,
         password: null,
       });
+      user.newlyCreated = true;
       this.usersService.fetchAndStoreProfilePicture(user, ftUser.image.link);
     }
     profile = user;

--- a/apps/web/components/ProfilePage/ChangePswrd.tsx
+++ b/apps/web/components/ProfilePage/ChangePswrd.tsx
@@ -3,6 +3,10 @@ import { useForm } from "react-hook-form";
 import styles from "styles/ChangePswrd.module.scss";
 import { Input } from "../Input";
 import { useRouter } from "next/router";
+import { clearTokens } from "../../helpers/clearTokens";
+import { setUserState } from "../../store/UserSlice";
+import { initUser } from "../../initType/UserInit";
+import { useDispatch } from "react-redux";
 
 interface ChangePasswordFormData {
   old_password: string;
@@ -41,6 +45,7 @@ export default function ChangePswrd(): JSX.Element {
   const [formError, setFormError] = useState("");
   const [formSuccess, setFormSuccess] = useState("");
   const [loading, setLoading] = useState(false);
+  const dispatch = useDispatch();
   const {
     formState: { errors },
     handleSubmit,
@@ -58,8 +63,8 @@ export default function ChangePswrd(): JSX.Element {
           throw new Error("An unexpected error occured...");
         } else {
           setFormSuccess(response.message);
-          localStorage.removeItem("access_token");
-          router.push("/login");
+          clearTokens();
+          dispatch(setUserState(initUser));
         }
       })
       .catch((error) => {

--- a/apps/web/components/ProfilePage/ChangeUsername.tsx
+++ b/apps/web/components/ProfilePage/ChangeUsername.tsx
@@ -3,6 +3,8 @@ import { useForm } from "react-hook-form";
 import styles from "styles/ChangeUsername.module.scss";
 import { Input } from "../Input";
 import { useRouter } from "next/router";
+import { setUserName } from "../../store/UserSlice";
+import { useDispatch } from "react-redux";
 
 interface ChangeUsernameFormData {
   new_username: string;
@@ -39,6 +41,7 @@ export default function ChangeUsername(): JSX.Element {
   const [formError, setFormError] = useState("");
   const [formSuccess, setFormSuccess] = useState("");
   const [loading, setLoading] = useState(false);
+  const dispatch = useDispatch();
   const {
     formState: { errors },
     handleSubmit,
@@ -56,7 +59,7 @@ export default function ChangeUsername(): JSX.Element {
           throw new Error("An unexpected error occured...");
         } else {
           setFormSuccess(response.message);
-          router.reload();
+          dispatch(setUserName(data.new_username));
         }
       })
       .catch((error) => {

--- a/apps/web/components/ProfilePage/ConfigTfa/index.tsx
+++ b/apps/web/components/ProfilePage/ConfigTfa/index.tsx
@@ -5,7 +5,6 @@ import { selectUserState, toggleTfa } from "../../../store/UserSlice";
 import { ManageTfa } from "./ManageTfa";
 import { SetupTfa } from "./SetupTfa";
 import { CheckTfaToken } from "./CheckTfaToken";
-import { useWebsocketContext } from "../../Websocket";
 
 export default function ConfigTfa(): JSX.Element {
   const userState = useSelector(selectUserState);
@@ -14,10 +13,8 @@ export default function ConfigTfa(): JSX.Element {
   const [layout, setLayout] = useState(
     <SetupTfa setOtpauthUrl={setOtpauthUrl} />
   );
-  const websocket = useWebsocketContext();
 
   useEffect(() => {
-    console.log(userState);
     if (userState.tfaSetup) {
       setLayout(
         <ManageTfa
@@ -38,14 +35,6 @@ export default function ConfigTfa(): JSX.Element {
       );
     } else setLayout(<SetupTfa setOtpauthUrl={setOtpauthUrl} />);
   }, [otpAuthUrl, userState, dispatch]);
-
-  useEffect(() => {
-    if (websocket.general) {
-      websocket.general.on("settings_changed", () => {
-        console.log("new settings");
-      });
-    }
-  }, []);
 
   return (
     <div className={styles.container}>

--- a/apps/web/components/Routes.tsx
+++ b/apps/web/components/Routes.tsx
@@ -18,7 +18,7 @@ export default function Routes({ children }: RoutesProps): JSX.Element {
     if (!userState.id.length && isProtected) router.replace("/auth/login");
     else if (userState.id.length && !isProtected) router.replace("/");
     else setLoading(false);
-  }, [router.pathname, userState]);
+  }, [router.pathname, userState.id]);
   if (loading) return <Loading></Loading>;
   return <>{children}</>;
 }

--- a/apps/web/components/TfaForm.tsx
+++ b/apps/web/components/TfaForm.tsx
@@ -64,10 +64,9 @@ export function TfaForm(props: TfaFormProps): ReactElement {
           localStorage.setItem("access_token", response.access_token);
           localStorage.setItem("refresh_token", response.refresh_token);
           localStorage.removeItem("state");
+          localStorage.removeItem("state");
           const user = await identifyUser();
           if (user) dispatch(setUserState(user));
-          localStorage.removeItem("state");
-          return;
         }
       })
       .catch((error) => {

--- a/apps/web/components/TopBar.tsx
+++ b/apps/web/components/TopBar.tsx
@@ -14,7 +14,6 @@ import List from "./HomePage/List";
 import { Userfront as User } from "types";
 import { initUser } from "../initType/UserInit";
 import { clearTokens } from "../helpers/clearTokens";
-import { useRouter } from "next/router";
 
 interface propsTopBar {
   openToggle: boolean;
@@ -50,7 +49,6 @@ async function logout(): Promise<null> {
 }
 
 function TopBar(props: propsTopBar): JSX.Element {
-  const router = useRouter();
   const [value, setValue] = useState("");
   const [userList, setUserList] = useState([<></>]);
 

--- a/apps/web/pages/auth/oauth2/42.tsx
+++ b/apps/web/pages/auth/oauth2/42.tsx
@@ -56,7 +56,6 @@ export default function FtOauth2(): JSX.Element {
             localStorage.removeItem("state");
             const user = await identifyUser();
             if (user) dispatch(setUserState(user));
-            router.replace("/");
           } else if (
             "message" in response &&
             response.message === "Authentication factor needed"

--- a/apps/web/pages/auth/oauth2/42.tsx
+++ b/apps/web/pages/auth/oauth2/42.tsx
@@ -56,6 +56,9 @@ export default function FtOauth2(): JSX.Element {
             localStorage.removeItem("state");
             const user = await identifyUser();
             if (user) dispatch(setUserState(user));
+            if (response.username)
+              router.replace(`/profile/${response.username}`);
+            else router.replace("/");
           } else if (
             "message" in response &&
             response.message === "Authentication factor needed"

--- a/apps/web/pages/auth/tfa.tsx
+++ b/apps/web/pages/auth/tfa.tsx
@@ -11,15 +11,9 @@ export default function Tfa(): JSX.Element {
   const [state, setState] = useState("");
 
   useEffect(() => {
-    if (accessToken) {
-      router.replace("/");
-      localStorage.removeItem("state");
-      return;
-    }
-
     const localState = localStorage.getItem("state");
     if (localState === null) {
-      router.replace("/auth/login");
+      if (!localStorage.getItem("access_token")) router.replace("/auth/login");
       return;
     }
 

--- a/apps/web/pages/profile/[username].tsx
+++ b/apps/web/pages/profile/[username].tsx
@@ -73,6 +73,7 @@ export default function Profil(): JSX.Element {
   /*==========================================================*/
 
   useEffect((): void => {
+    if (!localStorage.getItem("access_token")) return;
     if (router.query.username !== UserState.name) {
       // if foreign user
       fetch(`/api/user/${router.query.username}`, {

--- a/apps/web/store/UserSlice.ts
+++ b/apps/web/store/UserSlice.ts
@@ -15,13 +15,16 @@ export const UserSlice = createSlice({
     setUserState(state, action) {
       return action.payload;
     },
+    setUserName(state, action) {
+      return { ...state, name: action.payload };
+    },
     toggleTfa(state) {
       state.tfaSetup = !state.tfaSetup;
     },
   },
 });
 
-export const { setUserState, toggleTfa } = UserSlice.actions;
+export const { setUserState, setUserName, toggleTfa } = UserSlice.actions;
 
 export const selectUserState: (state: AppState) => User = (state: AppState) =>
   state.user;

--- a/packages/types/src/entities/user.entity.ts
+++ b/packages/types/src/entities/user.entity.ts
@@ -83,4 +83,6 @@ export class User {
   @OneToOne(() => Profile, (profile) => profile.user)
   @JoinColumn()
   profile!: Profile;
+
+  newlyCreated?: boolean;
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -13,6 +13,7 @@ export interface FtUser {
 export interface AccessTokenResponse {
   access_token: string;
   refresh_token: string;
+  username?: string;
 }
 
 export interface TfaNeededResponse {


### PR DESCRIPTION
Instead of showing the user a different form, show its newly created profile page. 

:warning: Does not work with manual registration, because the username is already chosen and it is not defined by the subject so osef.

Merge after:
- #75 