### PR TITLE
refactor(web): remove 'you loose' or 'you win' phrase

### DIFF
--- a/apps/web/pages/pingPong/[id].tsx
+++ b/apps/web/pages/pingPong/[id].tsx
@@ -529,9 +529,7 @@ export default function PingPong(): JSX.Element {
         </div>
       ) : (
         <div className={styles.afterGameContainer}>
-          <h1 className={textStyles.saira + " " + styles.title}>
-            Game Over <br></br> You {win ? "win" : "loose"} this game !
-          </h1>
+          <h1 className={textStyles.saira + " " + styles.title}>Game Over</h1>
           <div className={styles.tableContainer}>
             <table>
               <thead>


### PR DESCRIPTION
Best way to fix the issue where the spectator gets "You loose this game".