### PR TITLE
Back: fix a friend relationship update logic bug

### DIFF
--- a/apps/api/src/friendships/friendships.service.ts
+++ b/apps/api/src/friendships/friendships.service.ts
@@ -48,7 +48,7 @@ export class FriendshipsService {
       },
     });
     if (!target) throw new NotFoundException('Unknown user');
-    if (targetFriend) return this.update(target, currentUser.id);
+    if (targetFriend) return this.update(currentUser, target.id);
     const newFriendship = new friendshipsEntity();
     newFriendship.initiator = currentUser;
     newFriendship.target = target;


### PR DESCRIPTION
If a user added another user who had already invited him.